### PR TITLE
Update DSN to support special chars for user and password

### DIFF
--- a/src/DSN/DSN.php
+++ b/src/DSN/DSN.php
@@ -60,8 +60,8 @@ class DSN
         }
 
         $this->scheme = $parts['scheme'] ?? null;
-        $this->user = $parts['user'] ?? null;
-        $this->password = $parts['pass'] ?? null;
+        $this->user = isset($parts['user']) ? \urldecode($parts['user']) : null;
+        $this->password = isset($parts['pass']) ? \urldecode($parts['pass']) : null;
         $this->host = $parts['host'] ?? null;
         $this->port = $parts['port'] ?? null;
         $this->path = $parts['path'] ?? null;
@@ -129,7 +129,7 @@ class DSN
     }
 
     /**
-     * Return the query string
+     * Return the raw query string
      *
      * @return ?string
      */

--- a/src/DSN/DSN.php
+++ b/src/DSN/DSN.php
@@ -64,7 +64,7 @@ class DSN
         $this->password = isset($parts['pass']) ? \urldecode($parts['pass']) : null;
         $this->host = $parts['host'] ?? null;
         $this->port = $parts['port'] ?? null;
-        $this->path = $parts['path'] ?? null;
+        $this->path = isset($parts['path']) ? ltrim($parts['path'], '/') : null;
         $this->query = $parts['query'] ?? null;
     }
 
@@ -125,7 +125,7 @@ class DSN
      */
     public function getPath(): ?string
     {
-        return ltrim($this->path, '/');
+        return $this->path;
     }
 
     /**

--- a/tests/DSN/DSNTest.php
+++ b/tests/DSN/DSNTest.php
@@ -103,6 +103,39 @@ class DSNTest extends TestCase
         $this->assertEquals('region=us-east-1', $dsn->getQuery());
         $this->assertEquals('us-east-1', $dsn->getParam('region'));
         $this->assertEmpty($dsn->getParam('doesNotExist'));
+
+        $password = 'sl/sh+$@no:her';
+        $encoded = \urlencode($password);
+        $dsn = new DSN("sms://user:$encoded@localhost");
+        $this->assertEquals('sms', $dsn->getScheme());
+        $this->assertEquals('user', $dsn->getUser());
+        $this->assertEquals($password, $dsn->getPassword());
+        $this->assertEquals('localhost', $dsn->getHost());
+        $this->assertNull($dsn->getPort());
+        $this->assertEmpty($dsn->getPath());
+        $this->assertNull($dsn->getQuery());
+
+        $user = 'admin@example.com';
+        $encoded = \urlencode($user);
+        $dsn = new DSN("sms://$encoded@localhost");
+        $this->assertEquals('sms', $dsn->getScheme());
+        $this->assertEquals($user, $dsn->getUser());
+        $this->assertNull($dsn->getPassword());
+        $this->assertEquals('localhost', $dsn->getHost());
+        $this->assertNull($dsn->getPort());
+        $this->assertEmpty($dsn->getPath());
+        $this->assertNull($dsn->getQuery());
+
+        $value = 'I am 100% value=<complex>, "right"?!';
+        $encoded = \urlencode($value);
+        $dsn = new DSN("sms://localhost?value=$encoded");
+        $this->assertEquals('sms', $dsn->getScheme());
+        $this->assertNull($dsn->getUser());
+        $this->assertNull($dsn->getPassword());
+        $this->assertEquals('localhost', $dsn->getHost());
+        $this->assertNull($dsn->getPort());
+        $this->assertEmpty($dsn->getPath());
+        $this->assertEquals("value=$encoded", $dsn->getQuery());
     }
 
     public function testGetParam(): void


### PR DESCRIPTION
Previously, DSN would not be able to parse special characters like "@"
or "/". This adds support by requiring the input to be url encoded and
then DSN would decode it after parsing.