### PR TITLE
Allow constructing with null scheme

### DIFF
--- a/src/DSN/DSN.php
+++ b/src/DSN/DSN.php
@@ -71,9 +71,9 @@ class DSN
     /**
      * Return the scheme.
      *
-     * @return string
+     * @return ?string
      */
-    public function getScheme(): string
+    public function getScheme(): ?string
     {
         return $this->scheme;
     }

--- a/src/DSN/DSN.php
+++ b/src/DSN/DSN.php
@@ -5,9 +5,9 @@ namespace Utopia\DSN;
 class DSN
 {
     /**
-     * @var string
+     * @var ?string
      */
-    protected string $scheme;
+    protected ?string $scheme;
 
     /**
      * @var ?string


### PR DESCRIPTION
When constructing with a string with no scheme, we assign `null` to `$this->scheme`, but that throws a type exception because the property was not declared as nullable.

Needed so that from Appwrite, we can construct a database DSN from a simple string, or a properly formatted DSN.