### PR TITLE
feat: support parsing scheme-only DSNs

### DIFF
--- a/src/DSN/DSN.php
+++ b/src/DSN/DSN.php
@@ -20,9 +20,9 @@ class DSN
     protected ?string $password;
 
     /**
-     * @var string
+     * @var ?string
      */
-    protected string $host;
+    protected ?string $host;
 
     /**
      * @var ?string
@@ -55,6 +55,19 @@ class DSN
     {
         $parts = \parse_url($dsn);
 
+        // Handle scheme-only DSNs like "local://" which parse_url returns false for
+        if (!$parts && \str_ends_with($dsn, '://') && \strlen($dsn) > 3) {
+            $this->scheme = \substr($dsn, 0, -3);
+            $this->user = null;
+            $this->password = null;
+            $this->host = null;
+            $this->port = null;
+            $this->path = '';
+            $this->query = null;
+
+            return;
+        }
+
         if (!$parts) {
             throw new \InvalidArgumentException("Unable to parse DSN: $dsn");
         }
@@ -63,14 +76,10 @@ class DSN
             throw new \InvalidArgumentException('Unable to parse DSN: scheme is required');
         }
 
-        if (empty($parts['host'])) {
-            throw new \InvalidArgumentException('Unable to parse DSN: host is required');
-        }
-
         $this->scheme = $parts['scheme'];
         $this->user = isset($parts['user']) ? \urldecode($parts['user']) : null;
         $this->password = isset($parts['pass']) ? \urldecode($parts['pass']) : null;
-        $this->host = $parts['host'];
+        $this->host = $parts['host'] ?? null;
         $this->port = $parts['port'] ?? null;
         $this->path = isset($parts['path']) ? ltrim((string) $parts['path'], '/') : '';
         $this->query = $parts['query'] ?? null;
@@ -109,9 +118,9 @@ class DSN
     /**
      * Return the host
      *
-     * @return string
+     * @return ?string
      */
-    public function getHost(): string
+    public function getHost(): ?string
     {
         return $this->host;
     }

--- a/tests/DSN/DSNTest.php
+++ b/tests/DSN/DSNTest.php
@@ -148,9 +148,39 @@ class DSNTest extends TestCase
         $this->assertEquals('us-east-2', $dsn->getParam('region', 'us-east-2'));
     }
 
+    public function testSchemeOnly(): void
+    {
+        $dsn = new DSN('local://');
+        $this->assertEquals('local', $dsn->getScheme());
+        $this->assertNull($dsn->getUser());
+        $this->assertNull($dsn->getPassword());
+        $this->assertNull($dsn->getHost());
+        $this->assertNull($dsn->getPort());
+        $this->assertEmpty($dsn->getPath());
+        $this->assertNull($dsn->getQuery());
+
+        $dsn = new DSN('memory://');
+        $this->assertEquals('memory', $dsn->getScheme());
+        $this->assertNull($dsn->getUser());
+        $this->assertNull($dsn->getPassword());
+        $this->assertNull($dsn->getHost());
+        $this->assertNull($dsn->getPort());
+        $this->assertEmpty($dsn->getPath());
+        $this->assertNull($dsn->getQuery());
+
+        $dsn = new DSN('file://');
+        $this->assertEquals('file', $dsn->getScheme());
+        $this->assertNull($dsn->getUser());
+        $this->assertNull($dsn->getPassword());
+        $this->assertNull($dsn->getHost());
+        $this->assertNull($dsn->getPort());
+        $this->assertEmpty($dsn->getPath());
+        $this->assertNull($dsn->getQuery());
+    }
+
     public function testFail(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        new DSN('mariadb://');
+        new DSN('invalid-dsn-without-scheme');
     }
 }


### PR DESCRIPTION
## Summary
This PR adds support for parsing scheme-only DSNs like `local://`, `memory://`, `file://` etc.

## Changes
- Made `host` property nullable to support DSNs without a host
- Updated `getHost()` return type from `string` to `?string`
- Added special handling for scheme-only DSNs (e.g., `local://`) which PHP's `parse_url` returns `false` for
- Added tests for scheme-only DSN parsing

## Example Usage
```php
$dsn = new DSN('local://');
$dsn->getScheme(); // 'local'
$dsn->getHost();   // null
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DSN parser now supports scheme-only connection strings (e.g., "local://", "memory://", "file://")
  * Host parameter is now optional in DSN configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->